### PR TITLE
disable showDeprecation property in pom.xml

### DIFF
--- a/hush/pom.xml
+++ b/hush/pom.xml
@@ -58,7 +58,7 @@
         <configuration>
           <source>${jdkLevel}</source>
           <target>${jdkLevel}</target>
-          <showDeprecation>true</showDeprecation>
+          <showDeprecation>false</showDeprecation>
           <showWarnings>true</showWarnings>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <configuration>
           <source>${jdkLevel}</source>
           <target>${jdkLevel}</target>
-          <showDeprecation>true</showDeprecation>
+          <showDeprecation>false</showDeprecation>
           <showWarnings>true</showWarnings>
         </configuration>
       </plugin>


### PR DESCRIPTION
Hi Lars,

I failed to run mvn package with the following error:

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /Users/sho/tmp/hbase-book/hbase-book/ch04/src/main/java/coprocessor/EndpointProxyExample.java:[39,16] ?x??:[deprecation] org.apache.hadoop.hbase.client.HTable ?? getRegionsInfo() ?͐???????܂???B

[ERROR] /Users/sho/tmp/hbase-book/hbase-book/ch04/src/main/java/coprocessor/EndpointForMethodExample.java:[39,16] ?x??:[deprecation] org.apache.hadoop.hbase.client.HTable ?? getRegionsInfo() ?͐???????܂???B

[ERROR] /Users/sho/tmp/hbase-book/hbase-book/ch04/src/main/java/coprocessor/EndpointExample.java:[44,16] ?x??:[deprecation] org.apache.hadoop.hbase.client.HTable ?? getRegionsInfo() ?͐???????܂???B

[ERROR] /Users/sho/tmp/hbase-book/hbase-book/ch04/src/main/java/coprocessor/EndpointCombinedExample.java:[41,16] ?x??:[deprecation] org.apache.hadoop.hbase.client.HTable ?? getRegionsInfo() ?͐???????܂???B

```

This error is caused by showDeprecation option in pom.xml.
I'd like to request this patch to disable the property and fix this error.

Thanks,
Sho
