### PR TITLE
Changed command module to shell for disabling of transparent hugepages

### DIFF
--- a/cluster/ansible/roles/common/tasks/main.yml
+++ b/cluster/ansible/roles/common/tasks/main.yml
@@ -48,7 +48,10 @@
     - { name: 'net.ipv6.conf.default.disable_ipv6', value: '1', state: 'present' }
 
 - name: Disable transparent huge page defragmentation
-  command: echo never > /sys/kernel/mm/transparent_hugepage/defrag
+  shell: echo never > /sys/kernel/mm/transparent_hugepage/defrag
+
+- name: Disable transparent huge pages
+  shell: echo never > /sys/kernel/mm/transparent_hugepage/enabled
 
 - name: Set hostname
   hostname: name={{ inventory_hostname }}.{{ CLUSTER_DOMAIN }}


### PR DESCRIPTION
Changed command module to shell as command does not allow for > opera…tor and would have no effect on the system.

Added second echo according to Cloudera recommendations for disabling transparent hugepages.